### PR TITLE
Update compact_str to v0.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -162,6 +162,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 
 [[package]]
+name = "castaway"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46b662d08e94a6c8e715abef5e10e6fdf47c2be6375a5bb246b65c177d575eb7"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -197,12 +206,14 @@ dependencies = [
 
 [[package]]
 name = "compact_str"
-version = "0.2.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd1dddf0cf9b27908dba335f898b9915dfca771737104cd711438bbab20ea6ed"
+checksum = "fb6f80f92629b81f5b17b616a99f72870556ca457bbbd99aeda7bb5d194316a2"
 dependencies = [
+ "castaway",
+ "itoa 1.0.1",
+ "ryu",
  "serde",
- "static_assertions",
 ]
 
 [[package]]
@@ -990,6 +1001,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2cc38e8fa666e2de3c4aba7edeb5ffc5246c1c2ed0e3d17e560aeeba736b23f"
+
+[[package]]
 name = "ryu"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1159,12 +1176,6 @@ name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
-
-[[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ once_cell = "1.8.0"
 anyhow = "1.0"
 argh = "0.1.7"
 chrono = "0.4.19"
-compact_str = { version = "0.2.0", features = ["serde"] }
+compact_str = { version = "0.4", features = ["serde"] }
 fnv = "1.0.7"
 smallvec = { version = "1.7.0", features = ["const_new", "union", "write", "may_dangle"] }
 integer-encoding = { version = "3.0.2", features = ["tokio_async"] }

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,7 +2,7 @@ use std::fs::read;
 use std::net::SocketAddr;
 use std::path::PathBuf;
 
-use compact_str::CompactStr;
+use compact_str::CompactString;
 use fnv::FnvHashMap;
 
 pub fn configuration(config_file: PathBuf) -> anyhow::Result<Config> {
@@ -24,8 +24,8 @@ fn default_log_level() -> log::LevelFilter {
 #[derive(Clone, Debug, serde::Deserialize)]
 pub struct ServerConfig {
     pub bind: SocketAddr,
-    pub route: FnvHashMap<CompactStr, ServerRoute>,
-    pub token: CompactStr,
+    pub route: FnvHashMap<CompactString, ServerRoute>,
+    pub token: CompactString,
     pub max_concurrent_bidi_streams: Option<u32>,
 
     #[serde(deserialize_with = "crate::quic::deserialize_cert")]
@@ -44,9 +44,9 @@ pub struct ServerRoute {
 
 #[derive(Clone, Debug, serde::Deserialize)]
 pub struct ClientConfig {
-    pub remote: CompactStr,
-    pub route: FnvHashMap<CompactStr, ClientRoute>,
-    pub token: CompactStr,
+    pub remote: CompactString,
+    pub route: FnvHashMap<CompactString, ClientRoute>,
+    pub token: CompactString,
     pub retry_interval: Option<time_unit::TimeUnit>,
     pub max_retry: Option<usize>,
     pub max_concurrent_bidi_streams: Option<u32>,


### PR DESCRIPTION
**Context**
In the most recent version of [`compact_str`](https://github.com/ParkMyCar/compact_str), we renamed `CompactStr` to `CompactString`. You can continue to use `CompactStr` but there is a deprecation warning on it.

**Changes**
This PR updates `compact_str` to `v0.4`, renaming uses of `CompactStr` to `CompactString` to prevent the warning